### PR TITLE
build(docker): use pnpm for container builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,16 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-COPY package*.json ./
-RUN npm install
+# Install dependencies using pnpm
+COPY pnpm-lock.yaml package.json ./
+RUN corepack enable && pnpm install --frozen-lockfile
 
+# Copy the rest of the application code
 COPY . .
 
 EXPOSE 3000
 
-RUN npm run build
+# Build and start the application with pnpm
+RUN pnpm run build
 
-CMD ["npm", "start"]
+CMD ["pnpm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - .:/app
       - /app/node_modules
     command: >
-      sh -c "npx drizzle-kit push && npm run start"
+      sh -c "pnpm dlx drizzle-kit push && pnpm run start"
 
   db:
     image: postgres:15


### PR DESCRIPTION
## Summary
- use pnpm instead of npm in Dockerfile
- run development container commands with pnpm in docker-compose

## Testing
- `pnpm lint`
- `docker build -t tweakcn-test .` *(fails: Cannot connect to the Docker daemon)*
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68a86856d3488324abf0c62627455cf4